### PR TITLE
refactor(init): nest aggregate braces for 16-bit color types (mechanical)

### DIFF
--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -147,8 +147,8 @@ volatile uint32_t g_frame_seq_shown = 0;
 
 // Add state variables for waveform mode instances
 // CRITICAL: Preserve exact aggregate initialization syntax!
-CRGB16  waveform_last_color_primary = {0,0,0};
-CRGB16  waveform_last_color_secondary = {0,0,0};
+CRGB16  waveform_last_color_primary = {{ 0 }, { 0 }, { 0 }};
+CRGB16  waveform_last_color_secondary = {{ 0 }, { 0 }, { 0 }};
 
 SQ15x16 ui_mask[160];
 SQ15x16 ui_mask_height = 0.0;
@@ -355,7 +355,7 @@ SQ15x16 note_colors[12] = {
 
 // INCANDESCENT_LOOKUP ODR FIX [2025-09-19 17:15] - Moved from constants.h
 // CRITICAL: Preserve exact aggregate initialization syntax!
-CRGB16 incandescent_lookup = { 1.0000, 0.4453, 0.1562 };
+CRGB16 incandescent_lookup = {{ 1.0000 }, { 0.4453 }, { 0.1562 }};
 
 // LED_LERP ODR FIX [2025-09-19 17:15] - Moved from led_utilities.h
 LerpParams* led_lerp_params = NULL;

--- a/src/led_utilities.h
+++ b/src/led_utilities.h
@@ -210,7 +210,7 @@ inline CRGB16 hsv(SQ15x16 h, SQ15x16 s, SQ15x16 v) {
 
   CRGB base_color = CHSV(uint8_t(h * 255.0), uint8_t(s * 255.0), 255);
 
-  CRGB16 col = { base_color.r / 255.0, base_color.g / 255.0, base_color.b / 255.0 };
+  CRGB16 col = {{ base_color.r / 255.0 }, { base_color.g / 255.0 }, { base_color.b / 255.0 }};
   //col = desaturate(col, SQ15x16(1.0) - s);
 
   col.r *= v;
@@ -609,8 +609,8 @@ inline void render_photons_graph() {
   SQ15x16 tick_distance = (0.425 / (ticks - 1));
   SQ15x16 tick_pos = 0.025;
 
-  CRGB16 background = { 0.0, 0.0, 0.0 };
-  CRGB16 needle_color = { incandescent_lookup.r * incandescent_lookup.r * 0.9, incandescent_lookup.g * incandescent_lookup.g * 0.9, incandescent_lookup.b * incandescent_lookup.b * 0.9 };
+  CRGB16 background = {{ 0.0 }, { 0.0 }, { 0.0 }};
+  CRGB16 needle_color = {{ incandescent_lookup.r * incandescent_lookup.r * 0.9 }, { incandescent_lookup.g * incandescent_lookup.g * 0.9 }, { incandescent_lookup.b * incandescent_lookup.b * 0.9 }};
 
   //draw_line(leds_16_ui, 0.0, 0.5, background, 1.0);
 
@@ -621,7 +621,7 @@ inline void render_photons_graph() {
     SQ15x16 tick_brightness = 0.2 + 0.4 * prog;
     tick_brightness *= tick_brightness;
     tick_brightness *= tick_brightness;
-    CRGB16 tick_color = { 1.0 * tick_brightness, 0, 0 };
+    CRGB16 tick_color = {{ 1.0 * tick_brightness }, { 0 }, { 0 }};
 
     set_dot_position(GRAPH_DOT_1 + i, tick_pos);
     draw_dot(leds_16_ui, GRAPH_DOT_1 + i, tick_color);
@@ -685,8 +685,8 @@ inline void render_mood_graph() {
   SQ15x16 tick_distance = (0.425 / (ticks - 1));
   SQ15x16 tick_pos = 0.025;
 
-  CRGB16 background = { 0.0, 0.0, 0.0 };
-  CRGB16 needle_color = { incandescent_lookup.r * incandescent_lookup.r * 0.9, incandescent_lookup.g * incandescent_lookup.g * 0.9, incandescent_lookup.b * incandescent_lookup.b * 0.9 };
+  CRGB16 background = {{ 0.0 }, { 0.0 }, { 0.0 }};
+  CRGB16 needle_color = {{ incandescent_lookup.r * incandescent_lookup.r * 0.9 }, { incandescent_lookup.g * incandescent_lookup.g * 0.9 }, { incandescent_lookup.b * incandescent_lookup.b * 0.9 }};
 
   //draw_line(leds_16_ui, 0.0, 0.5, background, 1.0);
 
@@ -699,7 +699,7 @@ inline void render_mood_graph() {
     SQ15x16 tick_brightness = 0.1;  // + (0.025 * sin(radians * (1 << i)));  // + (0.04 * sin(radians * ((i<<1)+1)));
     SQ15x16 mix = i / float(ticks - 1);
 
-    CRGB16 tick_color = { tick_brightness * mix, 0.05 * tick_brightness, tick_brightness * (1.0 - mix) };
+    CRGB16 tick_color = {{ tick_brightness * mix }, { 0.05 * tick_brightness }, { tick_brightness * (1.0 - mix) }};
 
     set_dot_position(GRAPH_DOT_1 + i, tick_pos + (0.008 * sin(radians * (1 << i))));
     draw_dot(leds_16_ui, GRAPH_DOT_1 + i, tick_color);
@@ -960,7 +960,7 @@ inline void show_leds() {
     SQ15x16 bottom_value_g = 1 / backdrop_divisor;
     SQ15x16 bottom_value_b = 1 / backdrop_divisor;
 
-    CRGB16 backdrop_color = { bottom_value_r, bottom_value_g, bottom_value_b };
+    CRGB16 backdrop_color = {{ bottom_value_r }, { bottom_value_g }, { bottom_value_b }};
 
     SQ15x16 base_coat_width_scaled = base_coat_width * silent_scale;
 
@@ -1561,9 +1561,9 @@ inline void render_bulb_cover() {
 
   for (uint8_t i = 0; i < NATIVE_RESOLUTION; i++) {
     CRGB16 covered_color = {
-      leds_16[i].r * cover[i % 4],
-      leds_16[i].g * cover[i % 4],
-      leds_16[i].b * cover[i % 4],
+      { leds_16[i].r * cover[i % 4] },
+      { leds_16[i].g * cover[i % 4] },
+      { leds_16[i].b * cover[i % 4] },
     };
 
     SQ15x16 bulb_opacity = CONFIG.BULB_OPACITY;
@@ -1968,7 +1968,7 @@ inline CRGB16 adjust_hue_and_saturation(CRGB16 color, SQ15x16 hue, SQ15x16 satur
   b = fmax_fixed(SQ15x16(0.0), fmin_fixed(SQ15x16(1.0), b));
 
   // Return the resulting color
-  CRGB16 result = { r, g, b };
+  CRGB16 result = {{ r }, { g }, { b }};
   return result;
 }
 

--- a/src/lightshow_modes.h
+++ b/src/lightshow_modes.h
@@ -364,7 +364,7 @@ inline void light_mode_kaleidoscope() {
     g_val *= prog * brightness_mid;
     b_val *= prog * brightness_high;
 
-    CRGB16 col = { r_val, g_val, b_val };
+    CRGB16 col = {{ r_val }, { g_val }, { b_val }};
     // COMMENTED OUT [2025-09-20 15:45] - Bug: guaranteed 10% desaturation even at max CONFIG.SATURATION
     // col = desaturate(col, 0.1 + (0.9 - 0.9*CONFIG.SATURATION));
     // SATURATION FIX: Proper saturation control - only desaturate when CONFIG.SATURATION < 1.0
@@ -597,7 +597,7 @@ inline void light_mode_bloom(CRGB16* leds_prev_buffer) { // Accept previous buff
   }
   */
 
-  CRGB16 final_insert_color = { temp_col_rgb.r / 255.0, temp_col_rgb.g / 255.0, temp_col_rgb.b / 255.0 };
+  CRGB16 final_insert_color = {{ temp_col_rgb.r / 255.0 }, { temp_col_rgb.g / 255.0 }, { temp_col_rgb.b / 255.0 }};
   
   // Apply PHOTONS brightness scaling
   final_insert_color.r *= frame_config.PHOTONS;
@@ -1388,7 +1388,7 @@ inline void light_mode_waveform(CRGB16* leds_previous, CRGB16& last_color) { // 
   SQ15x16 smoothed_peak_fixed = SQ15x16(waveform_peak_scaled) * 0.02 + SQ15x16(waveform_peak_scaled_last) * 0.98;
   waveform_peak_scaled_last = float(smoothed_peak_fixed);
 
-  CRGB16 current_sum_color = {0,0,0};
+  CRGB16 current_sum_color = {{ 0 }, { 0 }, { 0 }};
   SQ15x16 total_magnitude = 0.0;
   
   for (uint8_t c = 0; c < 12; c++) {

--- a/src/p2p.h
+++ b/src/p2p.h
@@ -83,7 +83,7 @@ void identify_main_unit() {
     esp_now_send(peer_addr, (uint8_t *)&identify, sizeof(SB_COMMAND_IDENTIFY_MAIN));
   }
 
-  CRGB16 col = {1.0, 0.0, 0.0};
+  CRGB16 col = {{ 1.0 }, { 0.0 }, { 0.0 }};
   blocking_flash(col); // We aren't main unit, flash red
 }
 
@@ -205,7 +205,7 @@ void run_p2p() {
 
   if (flashing_flag) {
     flashing_flag = false;
-    CRGB16 col = {0.0, 1.0, 0.0};
+    CRGB16 col = {{ 0.0 }, { 1.0 }, { 0.0 }};
     blocking_flash(col);
   }
 }

--- a/src/serial_menu.h
+++ b/src/serial_menu.h
@@ -420,7 +420,7 @@ void parse_command(char* command_buf) {
   else if (strcmp(command_buf, "identify") == 0) {
 
     ack();
-    CRGB16 col = {1.00, 0.25, 0.00};
+    CRGB16 col = {{1.00}, {0.25}, {0.00}};
     blocking_flash(col);
 
   }


### PR DESCRIPTION
What
- Purely mechanical rewrite: convert flat {r,g,b}/{r,g,b,a} initializers to nested {{r},{g},{b}}/{{r},{g},{b},{a}} across 16-bit color types.

Why
- STRICT aggregate-init policy for C++17 safety; prevents silent FixedPoint corruption.

Touched Sites (from agent report)
- src/led_utilities.h:213/612/688/702/963/1560
- src/serial_menu.h:423
- src/lightshow_modes.h:367/600/1391
- src/p2p.h:86/208
- src/core/globals.cpp:150/151/358

Verification
- ./agent_runner.sh python3 tools/aggregate_init_scanner.py --mode=strict --roots src include lib → OK
- ./agent_runner.sh pio run → OK

Scope & Safety
- ❌ No new functions/vars; ❌ No logic changes
- ✅ Behavior preserved 1:1
