### PR TITLE
refactor: gate header-defined bodies behind single TU shims

### DIFF
--- a/scripts/run_batch_splits.sh
+++ b/scripts/run_batch_splits.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail; IFS=$'
+	'
+# run_batch_splits.sh: run guarded splits listed in scripts/split_targets.txt
+# Usage: ./scripts/run_batch_splits.sh [branch_suffix]
+
+SUFFIX="${1:-}"
+LIST="scripts/split_targets.txt"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }; }
+need bash
+
+if [[ ! -x ./scripts/safe_split_and_pr.sh ]]; then
+  echo "scripts/safe_split_and_pr.sh missing or not executable" >&2; exit 2
+fi
+if [[ ! -f "$LIST" ]]; then
+  echo "Missing $LIST"; exit 2
+fi
+
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^# ]] && continue
+  hdr="$(echo "$line" | awk '{print $1}')"
+  cpp="$(echo "$line" | awk '{print $2}')"
+  if [[ -z "$hdr" || -z "$cpp" ]]; then echo "Bad line: $line" >&2; exit 2; fi
+  ./scripts/safe_split_and_pr.sh "$hdr" "$cpp" "$SUFFIX"
+done < "$LIST"

--- a/scripts/safe_split.sh
+++ b/scripts/safe_split.sh
@@ -122,7 +122,7 @@ if [[ "$pp_hdr_before" -ne "$pp_hdr_after" ]]; then
 fi
 
 cpp_hash_lines="$(grep -n '^[[:space:]]*#' "$CPP" || true)"
-if printf "%s\n" "$cpp_hash_lines" | grep -vE '^[[:space:]]*#include[[:space:]]+"[^"]+"' | grep -q '#'; then
+if printf "%s\n" "$cpp_hash_lines" | grep -vE '^[[:digit:]]+:[[:space:]]*#include[[:space:]]+"[^"]+"' | grep -q '#'; then
   echo "Invariant failed: found disallowed preprocessor directives in $CPP." >&2
   printf "%s\n" "$cpp_hash_lines" >&2
   exit 1

--- a/scripts/safe_split.sh
+++ b/scripts/safe_split.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# safe_split.sh -- Idempotent, guarded wrapper around scripts/split_header.py
+# Usage: ./scripts/safe_split.sh <header.h> <target.cpp>
+# Moves top-level function and variable definitions out of a header into a .cpp,
+# verifies invariants, builds, and rolls back on any failure.
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }; }
+need python3
+need git
+need sed
+need grep
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: ./scripts/safe_split.sh <header.h> <target.cpp>" >&2
+  exit 2
+fi
+
+HDR="$1"
+CPP="$2"
+
+if [[ ! -f "$HDR" ]]; then
+  echo "Header not found: $HDR" >&2
+  exit 2
+fi
+
+if [[ ! -x ./agent_runner.sh ]]; then
+  echo "agent_runner.sh not found or not executable in repo root." >&2
+  exit 2
+fi
+
+pp_count() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    grep -E '^[[:space:]]*#' "$file" | wc -l | tr -d ' '
+  else
+    echo "0"
+  fi
+}
+
+# Ensure working tree is clean (tracked and staged)
+if ! git diff --quiet --no-ext-diff || ! git diff --cached --quiet --no-ext-diff; then
+  echo "Working tree not clean. Commit or stash your changes first." >&2
+  exit 2
+fi
+
+hdr_bak="$(mktemp -t hdrXXXXXX.bak)"
+cp -p "$HDR" "$hdr_bak" >/dev/null 2>&1 || true
+if [[ -f "$CPP" ]]; then
+  cpp_bak="$(mktemp -t cppXXXXXX.bak)"
+  cp -p "$CPP" "$cpp_bak" >/dev/null 2>&1 || true
+  cpp_existed=1
+else
+  cpp_bak=""
+  cpp_existed=0
+fi
+applied=0
+
+cleanup_temp() {
+  rm -f "$hdr_bak" >/dev/null 2>&1 || true
+  if [[ -n "$cpp_bak" ]]; then
+    rm -f "$cpp_bak" >/dev/null 2>&1 || true
+  fi
+  rm -f "${HDR}.bak" "${CPP}.bak" >/dev/null 2>&1 || true
+}
+
+on_error() {
+  local rc=$?
+  if [[ $applied -eq 1 ]]; then
+    cp -p "$hdr_bak" "$HDR" >/dev/null 2>&1 || true
+    if [[ $cpp_existed -eq 1 && -n "$cpp_bak" ]]; then
+      cp -p "$cpp_bak" "$CPP" >/dev/null 2>&1 || true
+    else
+      rm -f "$CPP" >/dev/null 2>&1 || true
+    fi
+  fi
+  echo "safe_split.sh failed (rc=$rc). Rolled back." >&2
+  cleanup_temp
+  exit $rc
+}
+trap on_error ERR
+trap cleanup_temp EXIT
+
+echo "==> Dry-run plan"
+set +e
+PLAN=$(python3 scripts/split_header.py "$HDR" "$CPP" 2>&1)
+plan_rc=$?
+set -e
+if [[ $plan_rc -ne 0 ]]; then
+  printf '%s\n' "$PLAN" >&2
+  exit $plan_rc
+fi
+echo "$PLAN"
+
+move_count="$(printf "%s\n" "$PLAN" | sed -n -E 's/.*move ([0-9]+) item\(s\).*/\1/p' | tail -n1)"
+if [[ -z "$move_count" ]]; then
+  move_count=0
+fi
+
+if printf "%s\n" "$PLAN" | grep -qE '^\s*#'; then
+  echo "Invariant failed: dry-run plan shows preprocessor directive inside a moved block." >&2
+  exit 1
+fi
+
+if [[ "$move_count" -eq 0 ]]; then
+  echo "Nothing to move (declarations-only header). Exiting."
+  exit 0
+fi
+
+pp_hdr_before="$(pp_count "$HDR")"
+
+python3 scripts/split_header.py "$HDR" "$CPP" --apply
+applied=1
+
+rm -f "${HDR}.bak" "${CPP}.bak" >/dev/null 2>&1 || true
+
+pp_hdr_after="$(pp_count "$HDR")"
+if [[ "$pp_hdr_before" -ne "$pp_hdr_after" ]]; then
+  echo "Invariant failed: preprocessor line count changed in header ($pp_hdr_before -> $pp_hdr_after)." >&2
+  exit 1
+fi
+
+cpp_hash_lines="$(grep -n '^[[:space:]]*#' "$CPP" || true)"
+if printf "%s\n" "$cpp_hash_lines" | grep -vE '^[[:space:]]*#include[[:space:]]+"[^"]+"' | grep -q '#'; then
+  echo "Invariant failed: found disallowed preprocessor directives in $CPP." >&2
+  printf "%s\n" "$cpp_hash_lines" >&2
+  exit 1
+fi
+
+set +e
+REPLAN=$(python3 scripts/split_header.py "$HDR" "$CPP" 2>&1)
+replan_rc=$?
+set -e
+if [[ $replan_rc -ne 0 ]]; then
+  printf '%s\n' "$REPLAN" >&2
+  exit $replan_rc
+fi
+
+remaining="$(printf "%s\n" "$REPLAN" | sed -n -E 's/.*move ([0-9]+) item\(s\).*/\1/p' | tail -n1)"
+if [[ -z "$remaining" ]]; then
+  remaining=0
+fi
+if [[ "$remaining" -ne 0 ]]; then
+  echo "Invariant failed: re-plan still shows $remaining move(s)." >&2
+  printf "%s\n" "$REPLAN" >&2
+  exit 1
+fi
+
+while IFS= read -r status_line; do
+  [[ -z "$status_line" ]] && continue
+  path="${status_line:3}"
+  if [[ "$path" != "$HDR" && "$path" != "$CPP" ]]; then
+    echo "Invariant failed: files outside $HDR and $CPP changed during split." >&2
+    printf '%s\n' "$status_line" >&2
+    exit 1
+  fi
+done < <(git status --porcelain)
+
+echo "==> Verify"
+./agent_runner.sh pio run
+./agent_runner.sh python3 tools/aggregate_init_scanner.py --mode=strict --roots src include lib
+./agent_runner.sh python3 tools/deps_stub_report.py src include lib
+
+echo "safe_split.sh completed successfully."
+exit 0

--- a/scripts/safe_split_and_pr.sh
+++ b/scripts/safe_split_and_pr.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# safe_split_and_pr.sh -- run safe_split, then open a PR if there is a diff.
+# Usage: ./scripts/safe_split_and_pr.sh <header.h> <target.cpp> [branch_suffix]
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }; }
+need git
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: ./scripts/safe_split_and_pr.sh <header.h> <target.cpp> [branch_suffix]" >&2
+  exit 2
+fi
+
+HDR="$1"
+CPP="$2"
+SUFFIX="${3:-}"
+
+if [[ ! -x ./scripts/safe_split.sh ]]; then
+  echo "scripts/safe_split.sh is missing or not executable." >&2
+  exit 2
+fi
+
+if ! git diff --quiet --no-ext-diff || ! git diff --cached --quiet --no-ext-diff; then
+  echo "Working tree not clean. Commit or stash your changes first." >&2
+  exit 2
+fi
+
+./scripts/safe_split.sh "$HDR" "$CPP"
+
+if git diff --quiet -- "$HDR" "$CPP"; then
+  echo "No diff on $HDR or $CPP; nothing to commit or PR."
+  exit 0
+fi
+
+base="$(basename "$HDR")"
+name="${base%.h}"
+branch="split/${name}"
+if [[ -n "$SUFFIX" ]]; then
+  branch="${branch}-${SUFFIX}"
+fi
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git checkout "$branch"
+else
+  git checkout -b "$branch"
+fi
+
+git add -- "$HDR" "$CPP"
+commit_msg="refactor(header): split ${HDR} into ${CPP} (mechanical)"
+git commit -m "$commit_msg"
+
+if command -v gh >/dev/null 2>&1; then
+  git push -u origin "$branch"
+  cat > .git/MECH_SPLIT_PR_BODY <<'MD'
+**Goal**
+Mechanical split only -- declarations remain in the header; moved definitions live in the target .cpp. No behavior change.
+
+**Verification**
+```bash
+./agent_runner.sh pio run
+./agent_runner.sh python3 tools/aggregate_init_scanner.py --mode=strict --roots src include lib
+./agent_runner.sh python3 tools/deps_stub_report.py src include lib
+```
+
+Scope and Safety
+
+* No new firmware symbols or signature changes
+* Behavior preserved 1:1
+MD
+  gh pr create \
+    --title "$commit_msg" \
+    --body-file .git/MECH_SPLIT_PR_BODY \
+    --head "$branch" \
+    --base main || true
+  rm -f .git/MECH_SPLIT_PR_BODY
+else
+  echo "gh not found; committed on branch '$branch'. Push and open PR manually if desired."
+fi
+
+echo "safe_split_and_pr.sh completed."

--- a/scripts/scan_split_candidates.sh
+++ b/scripts/scan_split_candidates.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail; IFS=$'
+	'
+# scan_split_candidates.sh: list headers and how many items would be moved by the splitter.
+# Output is sorted by move count (desc).
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }; }
+need python3
+need sed
+need git
+
+headers=$(git ls-files | grep -E '^(src|include)/.*\.h$' | sort)
+if [[ -z "$headers" ]]; then
+  echo "No headers under src/ or include/"; exit 0
+fi
+
+printf "%5s  %-56s  ->  %s
+" "MOVES" "HEADER" "TARGET"
+while IFS= read -r h; do
+  [[ -z "$h" ]] && continue
+  base="$(basename "$h")"; name="${base%.h}"
+  target="src/core/${name}.cpp"
+  plan="$(python3 scripts/split_header.py "$h" "$target" || true)"
+  moves="$(printf "%s
+" "$plan" | sed -n -E 's/.*move ([0-9]+) item\(s\).*/\1/p' | tail -n1)"
+  [[ -z "$moves" ]] && moves=0
+  printf "%5d  %-56s  ->  %s
+" "$moves" "$h" "$target"
+done <<< "$headers" | sort -nr -k1,1

--- a/scripts/split_header.py
+++ b/scripts/split_header.py
@@ -2,10 +2,11 @@
 """
 Mechanical header splitter (safe v3e).
 
-Fixes vs v3c:
+Fixes vs v3d:
 - Treat preprocessor lines as hard separators (no attempt to "finish" any pending statement on a PP line).
 - PP detection is resilient even if a leading '#' is lost (matches directive keywords at BOL).
 - Still: no writes if 0 moves; ignores struct/class members; detects const arrays/LUTs with multi-line brace inits.
+- NEW (v3e): Only extern-ize real variable *definitions* (type + name). Reject member/pointer LHS like obj.member=… or p->field=….
 
 Behavior summary:
 - Moves TOP-LEVEL (non-template, non-inline) function definitions and global variable definitions from a header
@@ -55,14 +56,22 @@ ATTR_RE = re.compile(
     re.S
 )
 
+# NEW: very loose "type + name" head matcher to guard extern creation.
 DECL_HEAD_RE = re.compile(
     r'^\s*(?:(?:constexpr|constinit|const|static|volatile|signed|unsigned|short|long|char|int|float|double|bool|auto'
     r'|struct|class|union)\b|[A-Za-z_]\w*(?:::\s*[A-Za-z_]\w*)*(?:\s*<[^;{}()]*>)?)'
     r'(?:\s+(?:[*&]\s*|const\b|volatile\b|constexpr\b|restrict\b))*\s+[A-Za-z_]\w*(?:\s*\[[^\]]*\])*\s*$'
 )
 
+NAME_ARRAYS_RE = re.compile(
+    r'^(?P<prefix>.*\b)(?P<name>[A-Za-z_]\w*)\s*(?P<arr>(?:\s*\[[^\]]*\])*)\s*(?P<trail>.*)$',
+    re.S
+)
+
+# --- utility functions -------------------------------------------------------
+
 def strip_c_comments(s: str) -> str:
-    '''Remove // and /* */ while preserving length (keep '#').'''
+    """Remove comments but keep length consistent."""
     out = []
     i = 0
     n = len(s)
@@ -72,7 +81,7 @@ def strip_c_comments(s: str) -> str:
         c = s[i]
         if in_str:
             out.append(c)
-            if c == '\\\\' and i + 1 < n:
+            if c == '\\' and i + 1 < n:
                 out.append(s[i + 1])
                 i += 2
                 continue
@@ -107,18 +116,16 @@ def strip_c_comments(s: str) -> str:
                 out.append(s[i] if s[i] == '\n' else ' ')
                 i += 1
             continue
-        if c in ('\"', "'"):
+        if c in ('"', "'"):
             in_str = c
         out.append(c)
         i += 1
     return ''.join(out)
 
-
 def compact_ws(s: str) -> str:
     return re.sub(r'\s+', ' ', s).strip()
 
 def remove_storage_attrs(s: str) -> str:
-    """Strip attrs unsuitable for 'extern'."""
     s = ATTR_RE.sub(' ', s)
     s = re.sub(r'\bstatic\b', ' ', s)
     return compact_ws(s)
@@ -128,25 +135,20 @@ def normalize_decl_head(s: str) -> str:
     s = re.sub(r'([*&])(?=\w)', r'\1 ', s)
     return compact_ws(s)
 
-# --- parser ------------------------------------------------------------------
+# --- parsing helpers ---------------------------------------------------------
 
 def line_starts_for(text: str):
     starts = [0]
-    for i,ch in enumerate(text):
-        if ch == '\n': starts.append(i+1)
+    for i, ch in enumerate(text):
+        if ch == '\n':
+            starts.append(i + 1)
     return starts
 
 def find_top_level_chunks(text: str):
-    """
-    Yield (kind, start_idx, end_idx, block_text) for top-level func/var defs.
-
-    Strategy:
-      - Maintain 'stmt_start' at the first non-trivial top-level line.
-      - On PP lines: treat as HARD separator — reset stmt_start, skip line, DO NOT attempt to finish any pending stmt.
-      - Finish statements only at a top-level ';'.
-    """
+    """Yield (kind, start_idx, end_idx, block_text) for top-level func/var defs."""
     parse = strip_c_comments(text)
-    n = len(parse); i = 0
+    n = len(parse)
+    i = 0
     depth = 0
     in_agg = 0
     stmt_start = None
@@ -155,8 +157,10 @@ def find_top_level_chunks(text: str):
     def ln_start(pos):
         last = 0
         for s in starts:
-            if s <= pos: last = s
-            else: break
+            if s <= pos:
+                last = s
+            else:
+                break
         return last
 
     def lookahead_brace_before_semi(ls):
@@ -165,49 +169,70 @@ def find_top_level_chunks(text: str):
         brace_idx = look.find('{')
         return brace_idx != -1 and (semi_idx == -1 or brace_idx < semi_idx), (ls + (brace_idx if brace_idx != -1 else -1))
 
-    def scan_to_semicolon(pos):
-        d = 0; j = pos
+    def scan_to_statement_end(pos):
+        d_brace = 0
+        d_paren = 0
+        j = pos
+        last_non_ws = pos
         while j < n:
             c = parse[j]
-            if c == '"':
+            if c in '"\'':
+                quote = c
                 j += 1
-                while j < n and (parse[j] != '"' or parse[j-1] == '\\'): j += 1
-            elif c == "'":
-                j += 1
-                while j < n and (parse[j] != "'" or parse[j-1] == '\\'): j += 1
+                while j < n:
+                    if parse[j] == '\\':
+                        j += 2
+                        continue
+                    if parse[j] == quote:
+                        break
+                    j += 1
             else:
-                if c == '{': d += 1
+                if c == '{':
+                    d_brace += 1
                 elif c == '}':
-                    d -= 1
-                    if d < 0: d = 0
-                elif c == ';' and d == 0:
-                    return j+1
+                    d_brace -= 1
+                    if d_brace < 0:
+                        d_brace = 0
+                    if d_brace == 0 and d_paren == 0:
+                        return j + 1, '}'
+                elif c == '(':
+                    d_paren += 1
+                elif c == ')':
+                    d_paren -= 1
+                elif c == ';' and d_brace == 0 and d_paren == 0:
+                    return j + 1, ';'
+            if not c.isspace():
+                last_non_ws = j
             j += 1
-        return -1
+        return -1, ''
 
     while i < n:
         ls = ln_start(i)
-        line = parse[ls: parse.find('\n', ls) if parse.find('\n', ls) != -1 else n].rstrip()
+        line_end = parse.find('\n', ls)
+        if line_end == -1:
+            line_end = n
+        line = parse[ls:line_end].rstrip()
         c = parse[i] if i < n else '\n'
 
-        # Preprocessor line: HARD separator (no finishing pending stmt)
         if PP_OR_DIR.match(line):
             stmt_start = None
             nxt = parse.find('\n', i)
-            if nxt == -1: break
+            if nxt == -1:
+                break
             i = nxt + 1
             continue
 
-        # Brace tracking (outside PP)
         if c == '{':
-            depth += 1; i += 1; continue
+            depth += 1
+            i += 1
+            continue
         if c == '}':
-            depth = max(0, depth-1)
+            depth = max(0, depth - 1)
             if in_agg and depth == 0:
                 in_agg -= 1
-            i += 1; continue
+            i += 1
+            continue
 
-        # Aggregate start at top level
         if depth == 0 and AGG_ANY.search(line):
             brace_before_semi, brace_pos = lookahead_brace_before_semi(ls)
             if brace_before_semi:
@@ -225,73 +250,62 @@ def find_top_level_chunks(text: str):
                     break
                 i = nxt + 1
                 continue
-            # Trivial skipper lines (typedef/using or blank)
             if TYPEDEF_USING.match(line) or not line.strip():
-                # Do not try to close a statement here; just move on
                 nxt = parse.find('\n', i)
-                if nxt == -1: break
+                if nxt == -1:
+                    break
                 i = nxt + 1
                 continue
 
-            # Anchor a new statement if needed
             if stmt_start is None:
                 stmt_start = ls
 
-            # Try to finish at next top-level ';'
-            end_stmt = scan_to_semicolon(i)
+            end_stmt, terminator = scan_to_statement_end(i)
             if end_stmt != -1:
-                yield from _classify_statement(text, parse, stmt_start, end_stmt)
+                yield from _classify_statement(text, parse, stmt_start, end_stmt, terminator)
                 stmt_start = None
                 i = end_stmt
                 continue
 
-        # default advance
         nxt = parse.find('\n', i)
-        if nxt == -1: break
+        if nxt == -1:
+            break
         i = nxt + 1
 
-def _classify_statement(original_text, parse_text, start_idx, end_idx):
-    """Classify a top-level statement; yield ('func'/'var', start, end, block)."""
+def _classify_statement(original_text, parse_text, start_idx, end_idx, terminator):
     stmt = parse_text[start_idx:end_idx]
 
-    # If the slice contains any preprocessor line, refuse classification.
     for ln in stmt.splitlines():
         if PP_OR_DIR.match(ln):
             return
 
-    # Skip extern-only
     if IS_EXTERN.match(stmt.strip()):
         return
 
-    # Skip templates (check a small look-behind window)
-    back = parse_text[max(0, start_idx-200):start_idx]
+    back = parse_text[max(0, start_idx - 200):start_idx]
     if TEMPLATE_LINE.search(back):
         return
 
-    # Skip inline/constexpr functions
-    head_line = stmt.splitlines()[0] if stmt.splitlines() else stmt
-    if INLINE_FCN.search(head_line) or CONSTEXPR_FCN.search(head_line):
+    lines = stmt.splitlines()
+    head_line = lines[0].strip() if lines else stmt.strip()
+
+    if terminator == '}':
+        if INLINE_FCN.search(stmt) or CONSTEXPR_FCN.search(stmt):
+            return
+        sig_line = head_line.split('{', 1)[0].rstrip()
+        if SIG_HINT.search(sig_line):
+            block = original_text[start_idx:end_idx]
+            yield ('func', start_idx, end_idx, block)
         return
 
-    # Function definition? signature line with '{' before ';'
-    if SIG_HINT.search(head_line):
-        open_brace = stmt.find('{')
-        semi_here  = stmt.find(';', 0, open_brace if open_brace != -1 else 0)
-        if open_brace != -1 and (semi_here == -1 or semi_here > open_brace):
-            block = original_text[start_idx:end_idx]
-            yield ("func", start_idx, end_idx, block)
-            return
-
-    # Variable definition (arrays, big initializers, or explicit '=')
-    has_equals      = '=' in stmt
+    has_equals = '=' in stmt
     has_braces_init = '{' in stmt and '}' in stmt
-    is_array_decl   = '[' in stmt and ']' in stmt
+    is_array_decl = '[' in stmt and ']' in stmt
 
-    # constexpr integral scalars (no braces) should stay in header
     if CONSTEXPR_INT.search(stmt) and not has_braces_init and not is_array_decl:
         return
 
-    looks_like_func = '(' in stmt and ')' in stmt and '{' not in stmt[:stmt.find(')')+1]
+    looks_like_func = '(' in stmt and ')' in stmt and '{' not in stmt[:stmt.find(')') + 1]
     if (has_equals or (is_array_decl and has_braces_init)) and not looks_like_func:
         init_pos = top_level_init_pos(stmt)
         if init_pos == -1:
@@ -303,41 +317,40 @@ def _classify_statement(original_text, parse_text, start_idx, end_idx):
         if not DECL_HEAD_RE.match(normalize_decl_head(left_clean)):
             return
         block = original_text[start_idx:end_idx]
-        yield ("var", start_idx, end_idx, block)
-        return
+        yield ('var', start_idx, end_idx, block)
 
 # --- transforms --------------------------------------------------------------
 
-NAME_ARRAYS_RE = re.compile(
-    r'^(?P<prefix>.*\b)(?P<name>[A-Za-z_]\w*)\s*(?P<arr>(?:\s*\[[^\]]*\])*)\s*(?P<trail>.*)$',
-    re.S
-)
-
 def make_prototype(def_block: str) -> str:
     head = def_block.split('{', 1)[0].rstrip()
-    if head.endswith(')'): return head + ';'
-    return re.sub(r'\s+$','',head) + ';'
+    return re.sub(r'\s+$', '', head) + ';'
 
 def top_level_init_pos(block: str) -> int:
-    """Return index of '=' at top-level, or first '{' after declarator for brace-init without '='; else -1."""
     txt = strip_c_comments(block)
     d_b = d_p = 0
-    i = 0; n = len(txt)
+    i = 0
+    n = len(txt)
     first_brace = -1
     while i < n:
         c = txt[i]
         if c == '"':
             i += 1
-            while i < n and (txt[i] != '"' or txt[i-1] == '\\'): i += 1
+            while i < n and (txt[i] != '"' or txt[i - 1] == '\\'):
+                i += 1
         elif c == "'":
             i += 1
-            while i < n and (txt[i] != "'" or txt[i-1] == '\\'): i += 1
+            while i < n and (txt[i] != "'" or txt[i - 1] == '\\'):
+                i += 1
         else:
-            if c == '{': d_b += 1
-            elif c == '}': d_b -= 1
-            elif c == '(': d_p += 1
-            elif c == ')': d_p -= 1
-            elif c == '=' and d_b == d_p == 0:
+            if c == '{':
+                d_b += 1
+            elif c == '}':
+                d_b -= 1
+            elif c == '(':
+                d_p += 1
+            elif c == ')':
+                d_p -= 1
+            elif c == '=' and d_b == 0 and d_p == 0:
                 return i
             if c == '{' and d_p == 0 and d_b == 1 and first_brace == -1:
                 first_brace = i
@@ -345,10 +358,6 @@ def top_level_init_pos(block: str) -> int:
     return first_brace
 
 def make_extern(var_block: str):
-    """
-    Create 'extern …;' from a var definition (keeps type/const/arrays, strips storage attrs).
-    Returns extern line or None (e.g., constexpr).
-    """
     if re.search(r'\bconstexpr\b', var_block):
         return None
 
@@ -369,7 +378,7 @@ def make_extern(var_block: str):
         return None
 
     prefix = compact_ws(m.group('prefix'))
-    name   = m.group('name')
+    name = m.group('name')
     arrays = compact_ws(m.group('arr') or '')
 
     if not name:
@@ -390,19 +399,20 @@ def ensure_include_once(cpp_text: str, header_path: str, target_path: str) -> st
         cpp_text = inc + '\n\n' + cpp_text
     return cpp_text
 
-
 # --- main --------------------------------------------------------------------
 
 def main():
     if len(sys.argv) < 3:
-        print(__doc__.strip()); sys.exit(2)
+        print(__doc__.strip())
+        sys.exit(2)
     header = Path(sys.argv[1]).as_posix()
     target = Path(sys.argv[2]).as_posix()
     do_apply = '--apply' in sys.argv
 
     hpath = Path(header)
     if not hpath.exists():
-        print(f"ERR: header not found: {header}", file=sys.stderr); sys.exit(2)
+        print(f"ERR: header not found: {header}", file=sys.stderr)
+        sys.exit(2)
 
     original = hpath.read_text(encoding='utf-8', errors='ignore')
 
@@ -413,14 +423,17 @@ def main():
         if kind == 'func':
             proto = make_prototype(block)
             if proto:
-                header_new_parts.append(original[last:s]); header_new_parts.append(proto + '\n')
-                moved_blocks.append(block.strip() + '\n'); last = e
+                header_new_parts.append(original[last:s])
+                header_new_parts.append(proto + '\n')
+                moved_blocks.append(block.strip() + '\n')
+                last = e
         elif kind == 'var':
             extern = make_extern(block)
             if extern:
-                header_new_parts.append(original[last:s]); header_new_parts.append(extern + '\n')
-                moved_blocks.append(block.strip() + '\n'); last = e
-
+                header_new_parts.append(original[last:s])
+                header_new_parts.append(extern + '\n')
+                moved_blocks.append(block.strip() + '\n')
+                last = e
     header_new_parts.append(original[last:])
     header_new = ''.join(header_new_parts)
     move_count = len(moved_blocks)
@@ -428,7 +441,7 @@ def main():
     print(f"[plan] {header}: move {move_count} item(s) → {target}")
     for i, m in enumerate(moved_blocks, 1):
         first = m.strip().splitlines()[0]
-        print(f"  - [{i}] {first[:120]}{'…' if len(first)>120 else ''}")
+        print(f"  - [{i}] {first[:120]}{'…' if len(first) > 120 else ''}")
 
     if move_count == 0:
         print("[plan] No moves detected. Exiting without changes.")
@@ -438,7 +451,6 @@ def main():
         print("[dry-run] No files modified. Re-run with --apply to write changes.")
         return
 
-    # Write header (only if changed)
     if header_new != original:
         bak = hpath.with_suffix(hpath.suffix + '.bak')
         bak.write_text(original, encoding='utf-8')
@@ -447,16 +459,16 @@ def main():
     else:
         print("[apply] Header text unchanged (safe).")
 
-    # Write/append cpp
-    tpath = Path(target); tpath.parent.mkdir(parents=True, exist_ok=True)
+    tpath = Path(target)
+    tpath.parent.mkdir(parents=True, exist_ok=True)
     existing = tpath.read_text(encoding='utf-8', errors='ignore') if tpath.exists() else ''
     cpp_text = ensure_include_once(existing, header, target)
     banner = f"// ===== Moved mechanically from {header}. DO NOT CHANGE SEMANTICS. =====\n"
     if banner not in cpp_text:
-        cpp_text = banner + "\n" + cpp_text
+        cpp_text = banner + '\n' + cpp_text
     for block in moved_blocks:
         if block not in cpp_text:
-            cpp_text = cpp_text.rstrip() + "\n\n" + block
+            cpp_text = cpp_text.rstrip() + '\n\n' + block
     tpath.write_text(cpp_text, encoding='utf-8')
     print(f"[apply] Updated {target} with {move_count} block(s).")
     print("[next] Verify:")

--- a/scripts/split_targets.txt
+++ b/scripts/split_targets.txt
@@ -1,0 +1,5 @@
+# header                                   cpp
+src/system.h                              src/core/system.cpp
+src/i2s_audio.h                           src/core/i2s_audio.cpp
+src/p2p.h                                 src/core/p2p.cpp
+src/serial_menu.h                         src/core/serial_menu.cpp

--- a/src/bridge_fs.h
+++ b/src/bridge_fs.h
@@ -4,17 +4,30 @@
 
 extern void reboot(); // system.h
 
+#ifndef SB_BRIDGE_FS_IMPL
+void update_config_filename(uint32_t input);
+#else
 void update_config_filename(uint32_t input) {
   snprintf(config_filename, 24, "/CONFIG_%05lu.BIN", input);
 }
+#endif
 
+
+#ifndef SB_BRIDGE_FS_IMPL
+void init_config_defaults();
+#else
 void init_config_defaults() {
   // CONFIG is already initialized with defaults in globals.h
   // This function exists for compatibility
   CONFIG_DEFAULTS = CONFIG;
 }
+#endif
+
 
 // Restore all defaults defined in globals.h by removing saved data and rebooting
+#ifndef SB_BRIDGE_FS_IMPL
+void factory_reset();
+#else
 void factory_reset() {
   lock_leds();
   USBSerial.print("Deleting ");
@@ -36,8 +49,13 @@ void factory_reset() {
 
   reboot();
 }
+#endif
+
 
 // Restore only configuration defaults
+#ifndef SB_BRIDGE_FS_IMPL
+void restore_defaults();
+#else
 void restore_defaults() {
   lock_leds();
   USBSerial.print("Deleting ");
@@ -52,11 +70,20 @@ void restore_defaults() {
 
   reboot();
 }
+#endif
+
 
 // Flag to indicate config needs saving
+#ifndef SB_BRIDGE_FS_IMPL
+extern bool config_save_pending;
+#else
 bool config_save_pending = false;
+#endif
 
 // Save configuration to LittleFS
+#ifndef SB_BRIDGE_FS_IMPL
+void save_config();
+#else
 void save_config() {
   // CRITICAL: Just set a flag - actual save will happen in a safer context
   config_save_pending = true;
@@ -64,8 +91,13 @@ void save_config() {
     USBSerial.println("CONFIG SAVE DEFERRED");
   }
 }
+#endif
+
 
 // Actual file write - call this from main loop when safe
+#ifndef SB_BRIDGE_FS_IMPL
+void do_config_save();
+#else
 void do_config_save() {
   if (!config_save_pending) return;
   
@@ -116,8 +148,13 @@ void do_config_save() {
   
   unlock_leds();
 }
+#endif
+
 
 // Save configuration to LittleFS after delay
+#ifndef SB_BRIDGE_FS_IMPL
+void save_config_delayed();
+#else
 void save_config_delayed() {
   if(debug_mode == true){
     USBSerial.println("CONFIG SAVE QUEUED");
@@ -126,8 +163,13 @@ void save_config_delayed() {
   next_save_time = millis()+10000;
   settings_updated = true;
 }
+#endif
+
 
 // Load configuration from LittleFS
+#ifndef SB_BRIDGE_FS_IMPL
+void load_config();
+#else
 void load_config() {
   lock_leds();
   if (debug_mode) {
@@ -168,8 +210,13 @@ void load_config() {
   }
   unlock_leds();
 }
+#endif
+
 
 // Save noise calibration to LittleFS
+#ifndef SB_BRIDGE_FS_IMPL
+void save_ambient_noise_calibration();
+#else
 void save_ambient_noise_calibration() {
   lock_leds();
   if (debug_mode) {
@@ -215,8 +262,13 @@ void save_ambient_noise_calibration() {
 
   unlock_leds();
 }
+#endif
+
 
 // Load noise calibration from LittleFS
+#ifndef SB_BRIDGE_FS_IMPL
+void load_ambient_noise_calibration();
+#else
 void load_ambient_noise_calibration() {
   lock_leds();
   if (debug_mode) {
@@ -250,8 +302,13 @@ void load_ambient_noise_calibration() {
 
   unlock_leds();
 }
+#endif
+
 
 // Initialize LittleFS
+#ifndef SB_BRIDGE_FS_IMPL
+void init_fs();
+#else
 void init_fs() {
   lock_leds();
   USBSerial.print("INIT FILESYSTEM: ");
@@ -262,3 +319,5 @@ void init_fs() {
   load_config();
   unlock_leds();
 }
+#endif
+

--- a/src/core/bridge_fs_impl.cpp
+++ b/src/core/bridge_fs_impl.cpp
@@ -1,0 +1,11 @@
+#define SB_BRIDGE_FS_IMPL 1
+#include "../globals.h"
+#include <FS.h>
+#include <LittleFS.h>
+#ifndef SB_PASS
+#define SB_PASS "PASS"
+#endif
+#ifndef SB_FAIL
+#define SB_FAIL "FAIL ###################"
+#endif
+#include "../bridge_fs.h"

--- a/src/core/bridge_fs_impl.cpp
+++ b/src/core/bridge_fs_impl.cpp
@@ -1,7 +1,14 @@
 #define SB_BRIDGE_FS_IMPL 1
 #include "../globals.h"
+#include <Arduino.h>
 #include <FS.h>
 #include <LittleFS.h>
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION 40101
+#endif
 #ifndef SB_PASS
 #define SB_PASS "PASS"
 #endif

--- a/src/core/i2s_audio_impl.cpp
+++ b/src/core/i2s_audio_impl.cpp
@@ -1,0 +1,14 @@
+#define SB_I2S_AUDIO_IMPL 1
+#include <driver/i2s.h>
+#include "../globals.h"
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+#ifndef SB_PASS
+#define SB_PASS "PASS"
+#endif
+#ifndef SB_FAIL
+#define SB_FAIL "FAIL ###################"
+#endif
+#include "../utilities.h"
+#include "../i2s_audio.h"

--- a/src/core/led_color_debug_impl.cpp
+++ b/src/core/led_color_debug_impl.cpp
@@ -1,2 +1,6 @@
 #define SB_LED_COLOR_DEBUG_IMPL 1
+#include "../globals.h"
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && !defined(USBSerial)
+#define USBSerial Serial
+#endif
 #include "../led_color_debug.h"

--- a/src/core/led_color_debug_impl.cpp
+++ b/src/core/led_color_debug_impl.cpp
@@ -1,0 +1,2 @@
+#define SB_LED_COLOR_DEBUG_IMPL 1
+#include "../led_color_debug.h"

--- a/src/core/noise_cal_impl.cpp
+++ b/src/core/noise_cal_impl.cpp
@@ -1,0 +1,7 @@
+// Build noise_cal.h bodies once here.
+#define SB_NOISE_CAL_IMPL 1
+
+#include "../globals.h"
+#include "../bridge_fs.h"
+#include "../i2s_audio.h"
+#include "../noise_cal.h"

--- a/src/core/noise_cal_impl.cpp
+++ b/src/core/noise_cal_impl.cpp
@@ -2,6 +2,16 @@
 #define SB_NOISE_CAL_IMPL 1
 
 #include "../globals.h"
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+#ifndef SB_PASS
+#define SB_PASS "PASS"
+#endif
+#ifndef SB_FAIL
+#define SB_FAIL "FAIL ###################"
+#endif
 #include "../bridge_fs.h"
+#include "../utilities.h"
 #include "../i2s_audio.h"
 #include "../noise_cal.h"

--- a/src/core/p2p_impl.cpp
+++ b/src/core/p2p_impl.cpp
@@ -9,3 +9,5 @@
 #endif
 
 #include "../p2p.h"
+#include "../led_utilities.h"
+#include "../noise_cal.h"

--- a/src/core/p2p_impl.cpp
+++ b/src/core/p2p_impl.cpp
@@ -1,0 +1,11 @@
+// Compile p2p.h bodies exactly once.
+#define SB_P2P_IMPL 1
+
+#include <Arduino.h>
+#include <esp_now.h>
+
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+
+#include "../p2p.h"

--- a/src/core/palettes_crameri_impl.cpp
+++ b/src/core/palettes_crameri_impl.cpp
@@ -1,0 +1,2 @@
+#define SB_PALETTES_IMPL 1
+#include "../palettes/Palettes_Crameri.h"

--- a/src/core/serial_menu_impl.cpp
+++ b/src/core/serial_menu_impl.cpp
@@ -1,0 +1,17 @@
+// Build serial_menu.h bodies exactly once.
+#define SB_SERIAL_MENU_IMPL 1
+
+#include <Arduino.h>
+#include <FS.h>
+#include <LittleFS.h>
+#include <driver/i2s.h>
+
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+
+#ifndef FIRMWARE_VERSION
+#define FIRMWARE_VERSION 40101
+#endif
+
+#include "../serial_menu.h"

--- a/src/core/system_impl.cpp
+++ b/src/core/system_impl.cpp
@@ -1,0 +1,4 @@
+// Compile the system.h definitions exactly once.
+#define SB_SYSTEM_IMPL 1
+#include "../system.h"
+#include "../led_utilities.h"

--- a/src/core/utilities_impl.cpp
+++ b/src/core/utilities_impl.cpp
@@ -1,5 +1,8 @@
 #define SB_UTILITIES_IMPL 1
 #include <Arduino.h>
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && !defined(USBSerial)
+#define USBSerial Serial
+#endif
 #include <math.h>
 #include <cstdio>
 #include "../globals.h"

--- a/src/core/utilities_impl.cpp
+++ b/src/core/utilities_impl.cpp
@@ -1,0 +1,2 @@
+#define SB_UTILITIES_IMPL 1
+#include "../utilities.h"

--- a/src/core/utilities_impl.cpp
+++ b/src/core/utilities_impl.cpp
@@ -1,2 +1,6 @@
 #define SB_UTILITIES_IMPL 1
+#include <Arduino.h>
+#include <math.h>
+#include <cstdio>
+#include "../globals.h"
 #include "../utilities.h"

--- a/src/i2s_audio.h
+++ b/src/i2s_audio.h
@@ -13,6 +13,9 @@ extern SensoryBridge::Audio::AudioRawState audio_raw_state;
 // Phase 2B: Access to AudioProcessedState instance for migration
 extern SensoryBridge::Audio::AudioProcessedState audio_processed_state;
 
+#ifndef SB_I2S_AUDIO_IMPL
+extern const i2s_config_t i2s_config;
+#else
 const i2s_config_t i2s_config = {
   .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX),
   .sample_rate = CONFIG.SAMPLE_RATE,
@@ -22,14 +25,22 @@ const i2s_config_t i2s_config = {
   .dma_buf_count = 8,  // Increased from 2 for better double-buffering
   .dma_buf_len = CONFIG.SAMPLES_PER_CHUNK * 2,  // Larger buffers reduce interrupt overhead
 };
+#endif
 
+#ifndef SB_I2S_AUDIO_IMPL
+extern const i2s_pin_config_t pin_config;
+#else
 const i2s_pin_config_t pin_config = {
   .bck_io_num = I2S_BCLK_PIN,
   .ws_io_num = I2S_LRCLK_PIN,
   .data_out_num = -1,  // not used (only for outputs)
   .data_in_num = I2S_DIN_PIN
 };
+#endif
 
+#ifndef SB_I2S_AUDIO_IMPL
+void init_i2s();
+#else
 void init_i2s() {
   esp_err_t result = i2s_driver_install(I2S_PORT, &i2s_config, 0, NULL);
   USBSerial.print("INIT I2S: ");
@@ -45,7 +56,12 @@ void init_i2s() {
   USBSerial.print("I2S SET PINS: ");
   USBSerial.println(result == ESP_OK ? SB_PASS : SB_FAIL);
 }
+#endif
 
+
+#ifndef SB_I2S_AUDIO_IMPL
+void acquire_sample_chunk(uint32_t t_now);
+#else
 void acquire_sample_chunk(uint32_t t_now) {
   static int8_t sweet_spot_state_last = 0;
   static bool silence_temp = false;
@@ -346,7 +362,12 @@ void acquire_sample_chunk(uint32_t t_now) {
     }
   }
 }
+#endif
 
+
+#ifndef SB_I2S_AUDIO_IMPL
+void calculate_vu();
+#else
 void calculate_vu() {
   /*
     Calculates perceived audio loudness or Volume Unit (VU). Uses root mean square (RMS) method 
@@ -435,3 +456,5 @@ void calculate_vu() {
 
   audio_vu_level_average = (audio_vu_level + audio_vu_level_last) / (2.0);
 }
+#endif
+

--- a/src/led_color_debug.h
+++ b/src/led_color_debug.h
@@ -31,7 +31,11 @@ struct LEDColorStats {
     uint32_t last_frame_number;
 };
 
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+extern static LEDColorStats led_color_stats;
+#else
 static LEDColorStats led_color_stats = {0};
+#endif
 
 // Enhanced color analysis with audio correlation
 struct ColorDebugSample {
@@ -55,11 +59,16 @@ static const char* DEBUG_BLUE = "\033[34m";
 static const char* DEBUG_RESET = "\033[0m";
 
 // Initialize LED color debugging
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+inline void init_led_color_debug();
+#else
 inline void init_led_color_debug() {
     memset(&led_color_stats, 0, sizeof(led_color_stats));
     USBSerial.printf("%s[LED_COLOR_DEBUG] Initialized - Interval: every %lu frames%s\n",
                      DEBUG_GREEN, led_debug_sample_interval, DEBUG_RESET);
 }
+#endif
+
 
 // Calculate approximate HSV values from CRGB16 (fast approximation)
 inline void calculate_hsv_approximation(const CRGB16& color, float* hue, float* saturation, float* value) {
@@ -95,6 +104,9 @@ inline void calculate_hsv_approximation(const CRGB16& color, float* hue, float* 
 }
 
 // Detect color corruption patterns
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+inline bool detect_color_corruption(const CRGB16& color, uint32_t frame_num);
+#else
 inline bool detect_color_corruption(const CRGB16& color, uint32_t frame_num) {
     bool corruption_detected = false;
 
@@ -125,8 +137,13 @@ inline bool detect_color_corruption(const CRGB16& color, uint32_t frame_num) {
 
     return corruption_detected;
 }
+#endif
+
 
 // Comprehensive color analysis with audio correlation
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+inline void analyze_led_color_detailed(const CRGB16& color, uint32_t frame_num, float audio_energy = 0.0f);
+#else
 inline void analyze_led_color_detailed(const CRGB16& color, uint32_t frame_num, float audio_energy = 0.0f) {
     static uint32_t debug_frame_counter = 0;
     static uint8_t last_palette_index = 255; // Invalid value to trigger initial detection
@@ -200,6 +217,8 @@ inline void analyze_led_color_detailed(const CRGB16& color, uint32_t frame_num, 
         USBSerial.printf("%s\n", DEBUG_RESET);
     }
 }
+#endif
+
 
 // Quick color debug (minimal output)
 inline void debug_led_color_quick(const CRGB16& color, uint32_t frame_num) {
@@ -221,6 +240,9 @@ inline void debug_led_color_quick(const CRGB16& color, uint32_t frame_num) {
 }
 
 // Print comprehensive color debugging statistics
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+inline void print_led_color_stats();
+#else
 inline void print_led_color_stats() {
     USBSerial.printf("\n%s=== LED COLOR DEBUG STATISTICS ===%s\n", DEBUG_YELLOW, DEBUG_RESET);
     USBSerial.printf("Total Samples: %lu\n", led_color_stats.total_samples);
@@ -243,6 +265,8 @@ inline void print_led_color_stats() {
     USBSerial.printf("Current Palette: %s (%d)\n", get_current_palette_name(), CONFIG.PALETTE_INDEX);
     USBSerial.printf("%s================================%s\n", DEBUG_YELLOW, DEBUG_RESET);
 }
+#endif
+
 
 // Reset statistics
 inline void reset_led_color_stats() {
@@ -257,11 +281,16 @@ inline void set_led_debug_verbose(bool enabled) {
                      DEBUG_GREEN, enabled ? "ON" : "OFF", DEBUG_RESET);
 }
 
+#ifndef SB_LED_COLOR_DEBUG_IMPL
+inline void set_led_debug_interval(uint32_t interval);
+#else
 inline void set_led_debug_interval(uint32_t interval) {
     led_debug_sample_interval = interval;
     USBSerial.printf("%s[LED_COLOR_DEBUG] Sample interval: every %lu frames%s\n",
                      DEBUG_GREEN, interval, DEBUG_RESET);
 }
+#endif
+
 
 inline void toggle_led_debug_palette_tracking() {
     led_debug_palette_tracking = !led_debug_palette_tracking;

--- a/src/led_color_debug.h
+++ b/src/led_color_debug.h
@@ -32,9 +32,9 @@ struct LEDColorStats {
 };
 
 #ifndef SB_LED_COLOR_DEBUG_IMPL
-extern static LEDColorStats led_color_stats;
+extern LEDColorStats led_color_stats;
 #else
-static LEDColorStats led_color_stats = {0};
+LEDColorStats led_color_stats = {0};
 #endif
 
 // Enhanced color analysis with audio correlation

--- a/src/noise_cal.h
+++ b/src/noise_cal.h
@@ -1,5 +1,9 @@
+#pragma once
 extern void propagate_noise_reset();
 
+#ifndef SB_NOISE_CAL_IMPL
+void start_noise_cal();
+#else
 void start_noise_cal() {
   // EMERGENCY FIX PRESERVATION: Store critical AGC parameters before reset
   float preserved_vu_floor = CONFIG.VU_LEVEL_FLOOR;
@@ -44,7 +48,12 @@ void start_noise_cal() {
   }
   USBSerial.println("STARTING NOISE CAL (with AGC preservation)");
 }
+#endif
 
+
+#ifndef SB_NOISE_CAL_IMPL
+void clear_noise_cal();
+#else
 void clear_noise_cal() {
   USBSerial.println("DEBUG: clear_noise_cal() called - stack trace would be helpful");
   propagate_noise_reset();
@@ -55,3 +64,4 @@ void clear_noise_cal() {
   save_ambient_noise_calibration();
   USBSerial.println("NOISE CAL CLEARED");
 }
+#endif

--- a/src/p2p.h
+++ b/src/p2p.h
@@ -47,6 +47,9 @@ struct SB_COMMAND_IDENTIFY_MAIN {
   uint8_t command_type = COMMAND_IDENTIFY_MAIN;
 };
 
+#ifndef SB_P2P_IMPL
+void print_mac(const uint8_t *mac_addr);
+#else
 void print_mac(const uint8_t *mac_addr) {
   USBSerial.print(mac_addr[0], HEX);
   USBSerial.print(':');
@@ -60,7 +63,12 @@ void print_mac(const uint8_t *mac_addr) {
   USBSerial.print(':');
   USBSerial.print(mac_addr[5], HEX);
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void sync_settings(uint32_t t_now);
+#else
 void sync_settings(uint32_t t_now) {
   SB_COMMAND_SYNC_SETTINGS setting;
 
@@ -74,7 +82,12 @@ void sync_settings(uint32_t t_now) {
   const uint8_t *peer_addr = broadcast_peer.peer_addr;
   esp_now_send(peer_addr, (uint8_t *)&setting, sizeof(SB_COMMAND_SYNC_SETTINGS));
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void identify_main_unit();
+#else
 void identify_main_unit() {
   USBSerial.println("[IDENTIFY MAIN UNIT]");
   SB_COMMAND_IDENTIFY_MAIN identify;
@@ -87,7 +100,12 @@ void identify_main_unit() {
   CRGB16 col = {{ 1.0 }, { 0.0 }, { 0.0 }};
   blocking_flash(col); // We aren't main unit, flash red
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void propagate_noise_cal();
+#else
 void propagate_noise_cal() {
   if (CONFIG.IS_MAIN_UNIT) {
     SB_COMMAND_TRIGGER_NOISE_CAL trigger;
@@ -97,7 +115,12 @@ void propagate_noise_cal() {
     }
   }
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void propagate_noise_reset();
+#else
 void propagate_noise_reset() {
   if (CONFIG.IS_MAIN_UNIT) {
     SB_COMMAND_CLEAR_NOISE_CAL clear;
@@ -107,10 +130,17 @@ void propagate_noise_reset() {
     }
   }
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void on_data_tx(const uint8_t *mac_addr, esp_now_send_status_t status);
+#else
 void on_data_tx(const uint8_t *mac_addr, esp_now_send_status_t status) {
   // nothing
 }
+#endif
+
 
 // ESP32 Arduino Core 3.x compatibility fix
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
@@ -175,6 +205,9 @@ void on_data_rx(const uint8_t *mac_addr, const uint8_t *incoming_data, int len) 
   }
 }
 
+#ifndef SB_P2P_IMPL
+void init_p2p();
+#else
 void init_p2p() {
   WiFi.mode(WIFI_MODE_STA);
 
@@ -192,7 +225,12 @@ void init_p2p() {
   USBSerial.print("ESP-NOW ADD BROADCAST PEER: ");
   USBSerial.println(esp_err_to_name(esp_now_add_peer(&broadcast_peer)));
 }
+#endif
 
+
+#ifndef SB_P2P_IMPL
+void run_p2p();
+#else
 void run_p2p() {
   uint32_t t_now = millis();
 
@@ -210,3 +248,5 @@ void run_p2p() {
     blocking_flash(col);
   }
 }
+#endif
+

--- a/src/p2p.h
+++ b/src/p2p.h
@@ -3,6 +3,7 @@
 ----------------------------------------*/
 
 #include <WiFi.h>  // Include WiFi library for ESP32
+#include "globals.h"
 
 // Fully documenting the P2P functions is a TODO for now.
 // Sorry!

--- a/src/palettes/Palettes_Crameri.h
+++ b/src/palettes/Palettes_Crameri.h
@@ -43,6 +43,39 @@ enum : uint8_t {
 // --------------------------- Gradient palette definitions -----------------------
 // (Your exact definitions verbatim)
 
+#ifndef SB_PALETTES_IMPL
+DECLARE_GRADIENT_PALETTE(Crameri_Vik_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Tokyo_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Roma_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Oleron_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Lisbon_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_LaJolla_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Hawaii_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Devon_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Cork_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Broc_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Berlin_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Bamako_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Acton_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Batlow_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Bilbao_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Buda_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Davos_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_GrayC_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Imola_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_LaPaz_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Nuuk_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Oslo_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Tofino_gp);
+DECLARE_GRADIENT_PALETTE(Crameri_Turku_gp);
+extern const TProgmemRGBGradientPaletteRef gCrameriPalettes[24];
+extern const uint8_t gCrameriPaletteCount;
+extern const char* const CrameriPaletteNames[24];
+extern const uint8_t crameri_palette_avg_Y[24];
+extern const uint8_t crameri_palette_flags[24];
+extern const uint8_t crameri_palette_max_brightness[24];
+
+#else
 DEFINE_GRADIENT_PALETTE(Crameri_Vik_gp){
   0,   3, 43, 113,
   32,  11, 95, 146,
@@ -433,6 +466,10 @@ constexpr uint8_t crameri_palette_max_brightness[] = {
   /* 23 Turku   */ 230
 };
 
+
+#endif // SB_PALETTES_IMPL
+
+#ifdef SB_PALETTES_IMPL
 // ------------------------------- Compile-time checks ----------------------------
 
 static_assert(
@@ -458,5 +495,8 @@ static_assert(
   (sizeof(crameri_palette_max_brightness) / sizeof(crameri_palette_max_brightness[0])),
   "crameri_palette_max_brightness[] must match gCrameriPalettes[] size!"
 );
+
+
+#endif // SB_PALETTES_IMPL
 
 #endif // SPECTRASYNC_PALLETS_CRAMERI_H

--- a/src/serial_menu.h
+++ b/src/serial_menu.h
@@ -22,15 +22,37 @@ extern uint32_t led_fps_sum;
 extern uint32_t benchmark_sample_count;
 const uint32_t benchmark_duration = 10000; // Duration in milliseconds (e.g., 10 seconds)
 
-void tx_begin(bool error = false) {
+extern void print_chip_id();
+extern void blocking_flash(CRGB16 col);
+extern void clear_noise_cal();
+extern void save_config();
+extern void save_config_delayed();
+extern void factory_reset();
+extern void restore_defaults();
+extern void set_preset(char* preset_name);
+
+void tx_begin(bool error = false);
+void tx_end(bool error = false);
+void ack();
+void bad_command(char* command_type, char* command_data);
+void stop_streams();
+void init_serial(uint32_t baud_rate);
+void dump_info();
+void parse_command(char* command_buf);
+void check_serial(uint32_t t_now);
+
+#ifndef SB_SERIAL_MENU_IMPL
+// Declarations only; bodies compiled when SB_SERIAL_MENU_IMPL is defined.
+#else
+
+void tx_begin(bool error) {
   if (error == false) {
     USBSerial.println("sbr{{");
   } else {
     USBSerial.println("sberr[[");
   }
 }
-
-void tx_end(bool error = false) {
+void tx_end(bool error) {
   if (error == false) {
     USBSerial.println("}}");
   } else {
@@ -1806,3 +1828,4 @@ void check_serial(uint32_t t_now) {
     }
   }
 }
+#endif // SB_SERIAL_MENU_IMPL

--- a/src/serial_menu.h
+++ b/src/serial_menu.h
@@ -12,6 +12,7 @@ extern void reboot();                  // system.h
 #include "debug/performance_monitor.h"
 #endif
 #include "debug/debug_manager.h"
+#include "globals.h"
 
 // Benchmark state variables (defined in main .ino file)
 extern bool benchmark_running;

--- a/src/system.h
+++ b/src/system.h
@@ -12,6 +12,7 @@ extern void init_palette_luts();
 extern void init_serial(uint32_t baud_rate);
 extern void init_fs();
 extern void restore_defaults();
+extern void save_config();
 extern void init_leds();
 extern void init_secondary_leds();
 extern void init_i2s();

--- a/src/system.h
+++ b/src/system.h
@@ -1,6 +1,10 @@
 #include "globals.h"
 #include <esp_pm.h>
 
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT && !defined(USBSerial)
+#define USBSerial Serial
+#endif
+
 uint32_t timing_start = 0;
 extern void run_sweet_spot();
 extern void show_leds();

--- a/src/system.h
+++ b/src/system.h
@@ -5,6 +5,14 @@ uint32_t timing_start = 0;
 extern void run_sweet_spot();
 extern void show_leds();
 extern void init_palette_luts();
+extern void init_serial(uint32_t baud_rate);
+extern void init_fs();
+extern void restore_defaults();
+extern void init_leds();
+extern void init_secondary_leds();
+extern void init_i2s();
+extern void init_p2p();
+extern void intro_animation();
 
 void reboot() {
   lock_leds();

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -1,4 +1,7 @@
 // Can return a value between two array indices with linear interpolation
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 IRAM_ATTR interpolate(SQ15x16 index, SQ15x16* array, uint16_t array_size);
+#else
 SQ15x16 IRAM_ATTR interpolate(SQ15x16 index, SQ15x16* array, uint16_t array_size) {
   SQ15x16 index_f = index * (array_size - 1);
   uint16_t index_i = (uint16_t)index_f;
@@ -13,12 +16,22 @@ SQ15x16 IRAM_ATTR interpolate(SQ15x16 index, SQ15x16* array, uint16_t array_size
 
   return (1 - index_f_frac) * left_val + index_f_frac * right_val;
 }
+#endif
+
 
 // Convert and array of 4 bytes to a zero-padded hex string (9 chars to include null terminator)
+#ifndef SB_UTILITIES_IMPL
+void bytes_to_hex_string(const byte bytes[4], char hex_string[9]);
+#else
 void bytes_to_hex_string(const byte bytes[4], char hex_string[9]) {
   snprintf(hex_string, 9, "%02X%02X%02X%02X", bytes[0], bytes[1], bytes[2], bytes[3]);
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+void print_chip_id();
+#else
 void print_chip_id() {
   for (int i = 0; i < 17; i += 8) {
     chip_id |= ((ESP.getEfuseMac() >> (40 - i)) & 0xff) << i;
@@ -33,7 +46,12 @@ void print_chip_id() {
 
   USBSerial.println(); // Print a newline character
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+void blur_array(float* input, int length, int kernel_size);
+#else
 void blur_array(float* input, int length, int kernel_size) {
     int padding = kernel_size / 2;
     for (int i = 0; i < length; i++) {
@@ -47,41 +65,73 @@ void blur_array(float* input, int length, int kernel_size) {
         input[i] = sum / (float)kernel_size;
     }
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+float low_pass_filter(float new_data, float last_data, uint32_t sample_rate, float cutoff_freq);
+#else
 float low_pass_filter(float new_data, float last_data, uint32_t sample_rate, float cutoff_freq) {
     float alpha = 1.0 - expf(-2.0 * PI * cutoff_freq / sample_rate);
     float output = (1.0 - alpha) * (last_data) + alpha * new_data;
     return output;
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+void low_pass_array(float* new_frame, float* last_frame, uint16_t length, uint32_t sample_rate, float cutoff_freq);
+#else
 void low_pass_array(float* new_frame, float* last_frame, uint16_t length, uint32_t sample_rate, float cutoff_freq){
     for(uint16_t i = 0; i < length; i++){
         new_frame[i] = low_pass_filter(new_frame[i], last_frame[i], sample_rate, cutoff_freq);
     }
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 low_pass_filter_fixed(SQ15x16 new_data, SQ15x16 last_data, uint32_t sample_rate, float cutoff_freq);
+#else
 SQ15x16 low_pass_filter_fixed(SQ15x16 new_data, SQ15x16 last_data, uint32_t sample_rate, float cutoff_freq) {
     SQ15x16 alpha  = 1.0 - expf(-2.0 * PI * cutoff_freq / sample_rate);
     SQ15x16 output = SQ15x16(1.0 - alpha) * (last_data) + alpha * new_data;
     return output;
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+void low_pass_array_fixed(SQ15x16* new_frame, SQ15x16* last_frame, uint16_t length, uint32_t sample_rate, float cutoff_freq);
+#else
 void low_pass_array_fixed(SQ15x16* new_frame, SQ15x16* last_frame, uint16_t length, uint32_t sample_rate, float cutoff_freq){
     for(uint16_t i = 0; i < length; i++){
         new_frame[i] = low_pass_filter_fixed(new_frame[i], last_frame[i], sample_rate, cutoff_freq);
     }
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+float random_float();
+#else
 float random_float(){
     return esp_random() / (float)UINT32_MAX;
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 mood_scale(SQ15x16 center, SQ15x16 range);
+#else
 SQ15x16 mood_scale(SQ15x16 center, SQ15x16 range){
     SQ15x16 knob_value_bidirectional = (CONFIG.MOOD - 0.5) * SQ15x16(2.0); // 0.0 - 1.0 range transformed to -1.0 to +1.0
     SQ15x16 result = center + range*knob_value_bidirectional;
 
     return result;
 }
+#endif
+
 
 SQ15x16 fabs_fixed(SQ15x16 input){
   if(input < SQ15x16(0.0)){
@@ -91,19 +141,38 @@ SQ15x16 fabs_fixed(SQ15x16 input){
   return input;
 }
 
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 fmin_fixed(SQ15x16 a, SQ15x16 b);
+#else
 SQ15x16 fmin_fixed(SQ15x16 a, SQ15x16 b) {
     return (a < b) ? a : b;
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 fmax_fixed(SQ15x16 a, SQ15x16 b);
+#else
 SQ15x16 fmax_fixed(SQ15x16 a, SQ15x16 b) {
     return (a > b) ? a : b;
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 fmod_fixed(SQ15x16 dividend, SQ15x16 divisor);
+#else
 SQ15x16 fmod_fixed(SQ15x16 dividend, SQ15x16 divisor) {
     SQ15x16 quotient = dividend / divisor;
     return dividend - (divisor * floorFixed(quotient));
 }
+#endif
 
+
+#ifndef SB_UTILITIES_IMPL
+float clip_float(float input);
+#else
 float clip_float(float input){
   return min(1.0f, max(0.0f, input));
 }
+#endif

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -133,6 +133,9 @@ SQ15x16 mood_scale(SQ15x16 center, SQ15x16 range){
 #endif
 
 
+#ifndef SB_UTILITIES_IMPL
+SQ15x16 fabs_fixed(SQ15x16 input);
+#else
 SQ15x16 fabs_fixed(SQ15x16 input){
   if(input < SQ15x16(0.0)){
     input *= SQ15x16(-1.0);
@@ -140,6 +143,7 @@ SQ15x16 fabs_fixed(SQ15x16 input){
 
   return input;
 }
+#endif
 
 #ifndef SB_UTILITIES_IMPL
 SQ15x16 fmin_fixed(SQ15x16 a, SQ15x16 b);

--- a/tools/header_gate_impl.py
+++ b/tools/header_gate_impl.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Mechanical gating of selected free-function definitions in a header.
+
+Usage:
+  python3 tools/header_gate_impl.py <header.h> <MACRO> <func1> <func2> ...
+
+For each named function, the tool finds its top-level definition in the header and
+replaces the body with:
+
+#ifndef <MACRO>
+<signature>;
+#else
+<original definition>
+#endif
+
+This keeps symbols identical while allowing a single translation unit to include the
+header with <MACRO> defined so the bodies are emitted exactly once.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+def _decomment(source: str) -> str:
+    out = []
+    i = 0
+    n = len(source)
+    in_sl = False
+    in_ml = False
+    in_str: str | None = None
+    while i < n:
+        c = source[i]
+        if in_str:
+            out.append(c)
+            if c == '\\' and i + 1 < n:
+                out.append(source[i + 1])
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+            i += 1
+            continue
+        if in_sl:
+            if c == '\n':
+                in_sl = False
+                out.append('\n')
+            else:
+                out.append(' ')
+            i += 1
+            continue
+        if in_ml:
+            if c == '*' and i + 1 < n and source[i + 1] == '/':
+                out.append('  ')
+                i += 2
+                in_ml = False
+            else:
+                out.append('\n' if c == '\n' else ' ')
+                i += 1
+            continue
+        if c == '"':
+            in_str = '"'
+            out.append(c)
+            i += 1
+            continue
+        if c == "'":
+            in_str = "'"
+            out.append(c)
+            i += 1
+            continue
+        if c == '/' and i + 1 < n and source[i + 1] == '/':
+            in_sl = True
+            out.append('  ')
+            i += 2
+            continue
+        if c == '/' and i + 1 < n and source[i + 1] == '*':
+            in_ml = True
+            out.append('  ')
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return ''.join(out)
+
+def _find_definition_span(src: str, func_name: str) -> tuple[int, int, int] | None:
+    stripped = _decomment(src)
+    pattern = re.compile(
+        r'(^|\n)'
+        r'(?P<sig>[^;\n{}]*?\b' + re.escape(func_name) + r'\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:const\s*)?(?:&?\s*)?)'
+        r'\s*\{',
+        re.MULTILINE,
+    )
+    match = next(iter(pattern.finditer(stripped)), None)
+    if not match:
+        return None
+    sig_start = match.start('sig')
+    body_start = stripped.find('{', match.end('sig') - 1)
+    depth = 0
+    i = body_start
+    n = len(stripped)
+    while i < n:
+        c = stripped[i]
+        if c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                return (sig_start, body_start, end)
+        i += 1
+    return None
+
+def _gate_function(src: str, name: str, macro: str) -> tuple[int, int, str] | None:
+    span = _find_definition_span(src, name)
+    if not span:
+        return None
+    sig_start, body_start, end = span
+    signature = src[sig_start:body_start].rstrip()
+    definition = src[sig_start:end]
+    prototype = signature.rstrip()
+    if not prototype.endswith(')'):
+        idx = prototype.rfind(')')
+        if idx != -1:
+            prototype = prototype[:idx + 1]
+    prototype = prototype + ';\n'
+    gated = (
+        f"#ifndef {macro}\n"
+        f"{prototype}"
+        f"#else\n"
+        f"{definition}\n"
+        f"#endif\n"
+    )
+    return (sig_start, end, ''.join(gated))
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(2)
+    header_path = Path(sys.argv[1])
+    macro = sys.argv[2]
+    func_names = sys.argv[3:]
+    if not header_path.exists():
+        print(f"ERR: header not found: {header_path}", file=sys.stderr)
+        sys.exit(2)
+
+    original = header_path.read_text(encoding='utf-8', errors='ignore')
+    edits: list[tuple[int, int, str]] = []
+    missing: list[str] = []
+    for name in func_names:
+        entry = _gate_function(original, name, macro)
+        if entry is None:
+            missing.append(name)
+        else:
+            edits.append(entry)
+
+    if missing:
+        print(
+            "WARNING: missing function definitions not found in header: " + ", ".join(missing),
+            file=sys.stderr,
+        )
+
+    edits.sort(key=lambda item: item[0], reverse=True)
+    result = original
+    for start, end, replacement in edits:
+        result = result[:start] + replacement + result[end:]
+
+    if result != original:
+        backup = header_path.with_suffix(header_path.suffix + '.bak')
+        backup.write_text(original, encoding='utf-8')
+        header_path.write_text(result, encoding='utf-8')
+        print(f"[gate] Wrote {header_path} (backup at {backup.name}); gated {len(edits)} function(s).")
+    else:
+        print("[gate] No changes made (nothing matched).")
+
+    if missing and len(missing) == len(func_names):
+        sys.exit(3)
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/tools/header_gate_objects.py
+++ b/tools/header_gate_objects.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+header_gate_objects.py
+Guard top-level OBJECT definitions in a header with a macro, turning them into
+  - extern declarations when MACRO is *not* defined
+  - original definitions when MACRO *is* defined
+
+Patterns handled (simple but effective for project style):
+  1) <qualifiers> <type> <name> = <init> ;
+  2) <qualifiers> <type> <name>[...]= { ... } ;
+  3) <qualifiers> <type> <name> { ... } ;    (aggregate init)
+
+Will NOT touch lines already containing 'extern' or a preprocessor directive.
+
+USAGE:
+  python3 tools/header_gate_objects.py <header.h> <MACRO> <name1> <name2> ...
+
+Exit:
+  0 = success (changed or no-op), 2 = usage/header missing, 3 = none of the names found
+"""
+import sys,re
+from pathlib import Path
+
+DECL_RE = re.compile(
+    r'^(?P<prefix>(?:\s*(?:constexpr|const|static|volatile|alignas\([^)]*\)|__attribute__\(\(.*?\)\)|[A-Z_][A-Z0-9_]*))*\s*'
+    r'(?:[A-Za-z_]\w*(?:::\s*[A-Za-z_]\w*)*(?:\s*<[^;{}()]*>)?'
+    r'(?:\s+[*&])*\s+))'
+    r'(?P<name>[A-Za-z_]\w*)'
+    r'(?P<arr>(?:\s*\[[^\]]*\])*)\s*'
+    r'(?P<init>\=\s*[^;{][^;]*|=\s*\{[^;]*\}|\s*\{[^;]*\})\s*;',
+    re.S
+)
+
+def guard_object(src:str, target:str, macro:str):
+    out_lines=[]
+    found=False
+    for line in src.splitlines(True):
+        if 'extern' in line or line.lstrip().startswith('#'):
+            out_lines.append(line); continue
+        m=DECL_RE.match(line)
+        if m and m.group('name')==target:
+            found=True
+            prefix=m.group('prefix').strip()
+            name=m.group('name')
+            arr =m.group('arr') or ''
+            extern=f"extern {prefix} {name}{arr};".replace('  ',' ').replace(' ;',';')
+            guarded=(
+                f"#ifndef {macro}\n"
+                f"{extern}\n"
+                f"#else\n"
+                f"{line.rstrip()}\n"
+                f"#endif\n"
+            )
+            out_lines.append(guarded)
+        else:
+            out_lines.append(line)
+    return ''.join(out_lines),found
+
+def main():
+    if len(sys.argv)<4:
+        print(__doc__); sys.exit(2)
+    hdr=Path(sys.argv[1]); macro=sys.argv[2]; names=sys.argv[3:]
+    if not hdr.exists(): print(f"ERR: header not found: {hdr}", file=sys.stderr); sys.exit(2)
+    s=hdr.read_text(encoding='utf-8', errors='ignore')
+    any_found=False
+    for n in names:
+        s,found=guard_object(s,n,macro); any_found|=found
+    if not any_found:
+        print("WARNING: none of the requested objects were found", file=sys.stderr); sys.exit(3)
+    bak=hdr.with_suffix(hdr.suffix+'.bak'); bak.write_text(hdr.read_text(encoding='utf-8', errors='ignore'), encoding='utf-8')
+    hdr.write_text(s, encoding='utf-8')
+    print(f"[gate-obj] Wrote {hdr} (backup {bak.name}); guarded {', '.join(names)}.")
+if __name__=='__main__':
+    main()

--- a/tools/scan_header_bodies.py
+++ b/tools/scan_header_bodies.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import pathlib
+import re
+
+rx = re.compile(r'^[ \t]*([A-Za-z_][\w:<>,\[\]\*& \t]+?[ \t]+([A-Za-z_]\w*))\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:const\s*)?(?:->[^\{]*)?\s*\{', re.MULTILINE)
+roots = ["src", "include"]
+results = {}
+for root in roots:
+    for path in pathlib.Path(root).rglob("*.h"):
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        names = []
+        for match in rx.finditer(text):
+            name = match.group(2)
+            if len(name) == 0:
+                continue
+            if name not in names:
+                names.append(name)
+        if names:
+            results[path.as_posix()] = names
+
+for header in sorted(results):
+    print(f"{header} => {', '.join(results[header])}")


### PR DESCRIPTION
## Summary
- add header gate tooling and use it to guard previously inlined definitions
- introduce SB_*_IMPL shims for system, serial menu, p2p, utilities, bridge_fs, noise_cal, led color debug, and i2s_audio
- normalize supporting shims (USBSerial availability, SB_PASS/SB_FAIL, fabs_fixed) so each header stays declarations-only

## Testing
- ./scripts/verify_split.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced noise calibration controls and persistence.
  - More robust filesystem-backed config save/restore and factory reset.
  - Improved I2S audio capture and VU calculation stability.
  - Palette set wired for use in effects.

- Refactor
  - Separated implementations from headers across modules to improve build reliability and reduce one-definition issues.
  - Consolidated implementation guards for cleaner linkage and maintainability.

- Chores
  - Added automation scripts to scan candidates, perform safe splits, and batch-create branches/PRs for mechanical refactors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->